### PR TITLE
Yank that Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'daily'
-    open-pull-requests-limit: 5


### PR DESCRIPTION
We're using Renvoate on this repo as is standard on dxw internal repos, so no need for Dependabout to be duplicating work