### PR TITLE
Update docker-compose to docker compose

### DIFF
--- a/script/ci/cibuild
+++ b/script/ci/cibuild
@@ -7,4 +7,4 @@ set -e
 
 cd "$(dirname "$0")/../.."
 
-docker-compose -f docker-compose.ci.yml -p app build
+docker compose -f docker-compose.ci.yml -p app build

--- a/script/ci/test
+++ b/script/ci/test
@@ -8,7 +8,7 @@ set -e
 
 cd "$(dirname "$0")/../.."
 
-docker-compose -f docker-compose.ci.yml \
+docker compose -f docker-compose.ci.yml \
             -p app \
             run --rm test \
             script/test "$@"


### PR DESCRIPTION
`docker-compose` is no longer supported, so we need to use `docker compose` instead. CI is failing on a bunch of dependency PRs because of this