### PR TITLE
Remove Docker caching from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,23 +18,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
-      - id: cache-docker
-        uses: actions/cache@v3
-        with:
-          path: /tmp/docker-save
-          key: docker-save-${{ hashFiles('Dockerfile', 'package-lock.json') }}
-
-      - if: steps.cache-docker.outputs.cache-hit == 'true'
-        name: Load cached Docker image
-        run: docker load -i /tmp/docker-save/snapshot.tar || true
-
       - name: Build
         run: script/ci/cibuild
 
       - name: Test
         run: script/ci/test
-
-      - if: always() && steps.cache-docker.outputs.cache-hit != 'true'
-        name: Prepare Docker cache
-        run: mkdir -p /tmp/docker-save && docker save app_test:latest -o
-          /tmp/docker-save/snapshot.tar && ls -lh /tmp/docker-save


### PR DESCRIPTION
Similar to in our Rails template, this seems to slow CI down quite substantially, so it's probably quicker not to use a cache

https://github.com/dxw/rails-template/commit/1f78864444f22c4ae4372a7a584fda1e55dba88f

CI ran in 2m4s here compared with 6m31s in #218 